### PR TITLE
Add Python3 provider setting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,7 @@ _G.User = {}
 
 require("core.utils")
 require("core.globals")
+require("core.envs")
 require("core.options")
 require("core.keymaps")
 require("core.lazy")

--- a/lua/core/envs.lua
+++ b/lua/core/envs.lua
@@ -1,0 +1,10 @@
+-- Python
+if vim.env["CONDA_PREFIX"] then
+  -- Use an independent environment `pynvim` for Neovim
+  local base_prefix = (vim.env["CONDA_PREFIX"]):match("^.-base")
+  local pynvim_python =
+    User.fn.path_concat(base_prefix, "envs", "pynvim", "bin", "python")
+  vim.g.python3_host_prog = pynvim_python
+end
+
+-- vim:sw=2:ts=2:sts=2:et:tw=80:cc=+1:norl:


### PR DESCRIPTION
The setting assumes that the package `pynvim` has been installed in an
independent conda environment named `pynvim`.
