### PR TITLE
Add range format key mapping

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,24 +1,20 @@
 -- Plugin-related table
 User.p = {}
 
-function User.p.format_and_save()
+function User.p.format()
   local bufnr = vim.api.nvim_get_current_buf()
   local ft = vim.bo[bufnr].filetype
   local has_null_ls = #require("null-ls.sources").get_available(
     ft,
     "NULL_LS_FORMATTING"
   ) > 0
-
-  -- Format
   vim.lsp.buf.format({
+    async = true,
     bufnr = bufnr,
     filter = function(client)
       return has_null_ls == (client.name == "null-ls")
     end,
   })
-
-  -- Save
-  vim.cmd("update")
 end
 
 function User.p.server_opts_with_fallback(opts)

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -96,7 +96,8 @@ return {
       },
       {
         "<Leader>lf",
-        "<Cmd>lua User.p.format_and_save()<CR>",
+        "<Cmd>lua User.p.format()<CR>",
+        mode = { "n", "x" },
         desc = "Format and save",
       },
       {


### PR DESCRIPTION
BREAKING CHANGE: the `User.p.format_on_save()` is `User.p.format()` now, which just formats the code in an async way.