### PR TITLE
Use utf-16 first for clangd offset encodings

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -111,7 +111,9 @@ return {
         -- `bash-language-server` for Bash
         bashls = {},
         -- `clangd` for C/C++
-        clangd = {},
+        clangd = {
+          offsetEncoding = { "utf-16", "utf-8" },
+        },
         -- `deno` for frontend
         denols = {
           filetypes = {


### PR DESCRIPTION
This avoids the "multiple different client offset_encodings detected" warning.

See https://github.com/neovim/nvim-lspconfig/issues/2184 for details.