### PR TITLE
Add system clipboard related keymaps

### DIFF
--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -45,7 +45,12 @@ set("x", "<", "<gv")
 set("x", ">", ">gv")
 
 -- Suspend
-set({"i", "n", "v"}, "<C-s>", "<Cmd>suspend<CR>")
+set({ "i", "n", "v" }, "<C-s>", "<Cmd>suspend<CR>")
+
+-- System clipboard
+set({ "n", "x" }, "<Leader>c", '"+y', "Copy to system clipboard")
+set("n", "<Leader>p", '"+p', "Paste from system clipboard")
+set("x", "<Leader>p", '"+P', "Paste from system clipboard")
 
 -- Toggle options
 set_toggle("b", "background", { "dark", "light" })
@@ -60,7 +65,7 @@ set_toggle("s", "spell")
 set_toggle("w", "wrap")
 
 -- Type commands quicker
-set({"n", "v"}, ";", ":")
+set({ "n", "v" }, ";", ":")
 
 -- Window actions
 set({ "", "!" }, "<Up>", "<Cmd>resize +1<CR>", "Increase height")

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -58,7 +58,6 @@ vim.opt.autochdir = true
 vim.opt.autowrite = true
 vim.opt.backspace = { "indent", "eol", "start" }
 vim.opt.breakindent = true
-vim.opt.clipboard = "unnamedplus"
 vim.opt.completeopt = { "menuone", "noselect", "noinsert" }
 vim.opt.confirm = true
 vim.opt.encoding = "utf-8"


### PR DESCRIPTION
BREAKING CHANGE: delete the `clipboard` option

Closes #34