### PR TITLE
New LSP and formatter

### DIFF
--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -15,7 +15,7 @@ return {
     },
     opts = {
       formatters_by_ft = {
-        ["*"] = { "typos", "codespell" },
+        ["*"] = { "typos", "codespell", "autocorrect" },
         bash = { "shfmt" },
         c = { { "clang_format", "ast-grep" } },
         cpp = { { "clang_format", "ast-grep" } },

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -120,6 +120,8 @@ return {
             },
           },
         },
+        -- `typos-lsp` for spell check
+        typos_lsp = {},
         -- `typst-lsp` for Typst
         typst_lsp = {
           settings = {


### PR DESCRIPTION
**ATTENTION** Formatting with `typos` may perform _unexpectedly_, e.g. Vim's `"enew"` to `"new"` (but in fact, technically, this performs as expected).