### PR TITLE
Fix argument jumping key mappings

### DIFF
--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -39,4 +39,15 @@ function User.fn.path_concat(base, ...)
   return ret
 end
 
+---feedkey() - Wrapped vim.api.nvim_feedkey
+---@param key string
+---@param mode string
+function User.fn.feedkey(key, mode)
+  vim.api.nvim_feedkeys(
+    vim.api.nvim_replace_termcodes(key, true, true, true),
+    mode,
+    true
+  )
+end
+
 -- vim:sw=2:ts=2:sts=2:et:tw=80:cc=+1:norl:

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -1,19 +1,3 @@
-function User.p.jump_next_with_fallback(key)
-  if vim.fn["vsnip#jumpable"](1) then
-    return "<Plug>(vsnip-jump-next)"
-  end
-
-  return key
-end
-
-function User.p.jump_prev_with_fallback(key)
-  if vim.fn["vsnip#jumpable"](-1) then
-    return "<Plug>(vsnip-jump-prev)"
-  end
-
-  return key
-end
-
 return {
   {
     "hrsh7th/nvim-cmp",
@@ -26,26 +10,6 @@ return {
       "hrsh7th/cmp-vsnip",
       "hrsh7th/vim-vsnip",
       "rcarriga/cmp-dap",
-    },
-    keys = {
-      {
-        "<Tab>",
-        function()
-          return User.p.jump_next_with_fallback("<Tab>")
-        end,
-        mode = { "i", "s" },
-        desc = "Jump to the next item",
-        expr = true,
-      },
-      {
-        "<S-Tab>",
-        function()
-          return User.p.jump_prev_with_fallback("<S-Tab>")
-        end,
-        mode = { "i", "s" },
-        desc = "Jump to the previous item",
-        expr = true,
-      },
     },
     opts = function()
       local cmp = require("cmp")
@@ -62,6 +26,18 @@ return {
           ["<C-]>"] = cmp.mapping.complete(),
           ["<C-e>"] = cmp.mapping.abort(),
           ["<CR>"] = cmp.mapping.confirm({ select = true }),
+          ["<Tab>"] = cmp.mapping(function(fallback)
+            if vim.fn["vsnip#jumpable"](1) == 1 then
+              User.fn.feedkey("<Plug>(vsnip-jump-next)", "")
+            else
+              fallback()
+            end
+          end, { "i", "s" }),
+          ["<S-Tab>"] = cmp.mapping(function()
+            if vim.fn["vsnip#jumpable"](-1) == 1 then
+              User.fn.feedkey("<Plug>(vsnip-jump-prev)", "")
+            end
+          end, { "i", "s" }),
         }),
         sources = cmp.config.sources({
           { name = "nvim_lsp" },


### PR DESCRIPTION
The original rough key mappings will trigger `<Esc>` (at least it behaves like that), which is not expected. It can be fixed by using [example mappings from the Wiki of `nvim-cmp`].

[example mappings from the Wiki of `nvim-cmp`]: https://github.com/hrsh7th/nvim-cmp/wiki/Example-mappings#vim-vsnip
